### PR TITLE
Point this fork of node-pty where it is built from

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "types": "./typings/node-pty.d.ts",
   "repository": {
     "type": "git",
-    "url": "git://github.com/Tyriar/node-pty.git"
+    "url": "https://github.com/theia-ide/node-pty"
   },
   "files": [
     "binding.gyp",
@@ -20,9 +20,9 @@
     "deps/",
     "typings/"
   ],
-  "homepage": "https://github.com/Tyriar/node-pty",
+  "homepage": "https://github.com/theia-ide/node-pty",
   "bugs": {
-    "url": "https://github.com/Tyriar/node-pty/issues"
+    "url": "https://github.com/theia-ide/node-pty/issues"
   },
   "keywords": [
     "pty",


### PR DESCRIPTION
https://www.npmjs.com/package/@theia/node-pty and the package.json points to the wrong place for this published fork